### PR TITLE
Fixed typo in 's5p4418.xml' for branch 'master-v18.06.1'

### DIFF
--- a/s5p4418.xml
+++ b/s5p4418.xml
@@ -13,7 +13,7 @@
   </project>
 
   <!-- friendlyelec device configs -->
-  <project path="device/friendlyelec" name="friendlywrt_device_s5p4418" remote="refs/heads/master-v18.06.1" />
+  <project path="device/friendlyelec" name="friendlywrt_device_s5p4418" remote="origin" revision="refs/heads/master-v18.06.1" />
   <project path="configs" name="friendlywrt_configs" remote="origin" revision="refs/heads/master-v18.06.1" />
 
   <!-- friendlyelec scripts -->


### PR DESCRIPTION
The typo in s5p4418.xml made the branch 'master-v18.06.1' didn't work with s5p4418, and the fix is in this PR.